### PR TITLE
update tests involving time to use predefined date mock

### DIFF
--- a/test/mock/text.mock.ts
+++ b/test/mock/text.mock.ts
@@ -1,2 +1,2 @@
 export const MOCK_NAMESPACE = 'namespace';
-export const MOCK_DATE = '1970-01-01 01:00:00.000+1';
+export const MOCK_DATE = '1999-01-01 00:00:00.000+0';

--- a/test/unit/formatting/humanFormat.spec.ts
+++ b/test/unit/formatting/humanFormat.spec.ts
@@ -3,7 +3,7 @@ import winston from 'winston';
 
 import * as humanFormat from '../../../src/formatting/humanFormat';
 import { MOCK_INFO, MOCK_HUMAN_MESSAGE, MOCK_FORMATTED_HUMAN_MESSAGE } from '../../mock/data.mock';
-import { MOCK_NAMESPACE } from '../../mock/text.mock';
+import { MOCK_DATE, MOCK_NAMESPACE } from '../../mock/text.mock';
 
 describe('humanFormat test suites', () => {
     afterEach(() => {
@@ -12,7 +12,7 @@ describe('humanFormat test suites', () => {
 
     describe('setHumanMessage test', () => {
         beforeEach(() => {
-            jest.useFakeTimers().setSystemTime();
+            jest.useFakeTimers().setSystemTime(new Date(MOCK_DATE));
         });
 
         afterEach(() => {

--- a/test/unit/formatting/jsonFormat.spec.ts
+++ b/test/unit/formatting/jsonFormat.spec.ts
@@ -4,7 +4,7 @@ import winston from 'winston';
 import * as jsonFormat from '../../../src/formatting/jsonFormat';
 
 import { MOCK_INFO, MOCK_JSON_OBJECT, MOCK_JSON_STRINGIFIED } from '../../mock/data.mock';
-import { MOCK_NAMESPACE } from '../../mock/text.mock';
+import { MOCK_DATE, MOCK_NAMESPACE } from '../../mock/text.mock';
 
 describe('jsonFormat test suites', () => {
     afterEach(() => {
@@ -13,7 +13,7 @@ describe('jsonFormat test suites', () => {
 
     describe('setJsonMessage Test', () => {
         beforeEach(() => {
-            jest.useFakeTimers().setSystemTime();
+            jest.useFakeTimers().setSystemTime(new Date(MOCK_DATE));
         });
         afterEach(() => {
             jest.useRealTimers();


### PR DESCRIPTION
### JIRA link

[NTRNL-267](https://technologyprogramme.atlassian.net/jira/software/projects/NTRNL/boards/312?selectedIssue=NTRNL-267)

### Description

Update tests involving time to use predefined date mock. This fixes the tests failing in CI as it prevents the GitHub Actions environment (timezone) from contaminating the test suite.

### Work checklist

- [ ] Tests added where applicable
- [x] No vulnerability added