### PR TITLE
add jest coverage threshold check in prepush and github action coverage

### DIFF
--- a/.github/workflows/jest-coverage-report.yml
+++ b/.github/workflows/jest-coverage-report.yml
@@ -1,0 +1,20 @@
+name: Jest Coverage Report
+
+on: [pull_request]
+
+jobs:
+  jest-coverage-report:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Coverage Report
+        uses: ArtiomTr/jest-coverage-report-action@v2

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm run test
+npm run coverage

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,6 +2,11 @@ module.exports = {
     roots: ['<rootDir>/src', '<rootDir>/test'],
     testPathIgnorePatterns: ['/node_modules/', '/lib/'],
     collectCoverageFrom: ['./src/**/*.ts'],
+    coverageThreshold: {
+        global: {
+            lines: 95,
+        },
+    },
     preset: 'ts-jest',
     testEnvironment: 'node',
     verbose: true,


### PR DESCRIPTION
Add Jest Coverage Threshold

### JIRA link

[NTRNL-283](https://technologyprogramme.atlassian.net/jira/software/projects/NTRNL/boards/312?selectedIssue=NTRNL-283)

### Description

Supersedes draft PR [#12](https://github.com/cabinetoffice/node-logging/pull/12). See this draft PR for original comments.

Add jest coverage threshold check in prepush and github action coverage.

### Work checklist

- [x] Tests added where applicable
- [x] No vulnerability added